### PR TITLE
Change pVal comparsion to strict to fix checkboxes in fastcompare

### DIFF
--- a/server/plugins/fastcompare/templates/fastcompare_create.html
+++ b/server/plugins/fastcompare/templates/fastcompare_create.html
@@ -482,7 +482,7 @@
                       let pVal = this.selectedAlgorithmsParameters[i][j].value;
                       let algoIdx = this.availableAlgorithmNames.indexOf(this.selectedAlgorithms[i]);
                       let algoParams = this.availableAlgorithmsData[algoIdx]["parameters"];
-                      result = result && pVal != null && pVal != '';
+                      result = result && pVal != null && pVal !== '';
                       if (result) {
                         let pType = this.findParamType(algoParams, j);
                         if (pType == "int") {


### PR DESCRIPTION
Again, this applies to `ndbi021`, unsure about other branches.
During the implementation of a new plugin to fastcompare, I have used the `ParameterType.BOOL` for some parameters of the algorithm. The problem is that in the current fastcompare template file, the following snippet of code "validates" the parameters.

https://github.com/pdokoupil/EasyStudy/blob/ac6ac7e4372e2f1cf707f9d439f159853fd61ed2/server/plugins/fastcompare/templates/fastcompare_create.html#L480-L494

In JavaScript, an unchecked checkbox results `let pVal = this.selectedAlgorithmsParameters[i][j].value;` in `pVal = false` (which is correct), but then the validation fails here: `result = result && pVal != null && pVal != '';` as `pval != ''` returns the wrong value, because `false` is a valid value for a checkbox (see the following image).

![image](https://github.com/pdokoupil/EasyStudy/assets/1692163/f1ef7cce-f0ff-4a6d-9ca7-4170ac7c17cd)

So, what all of this means is that the study cannot be created and there is no actual error description and I had no idea what's wrong. This pull request makes the comparsion strict which fixes the checkboxes problem.

To be honest, I'm not sure which of the comparsions should be `!==` instead of `!=` (resp. `===` vs `==`) in the entire file and if there are any similar issues. I don't have time to go through this, maybe using some linter would help.
